### PR TITLE
feat(mvc/associationCtrl): Association Controller

### DIFF
--- a/DutchTreat/Controllers/OrderItemsController.cs
+++ b/DutchTreat/Controllers/OrderItemsController.cs
@@ -1,0 +1,55 @@
+﻿using AutoMapper;
+using DutchTreat.Data;
+using DutchTreat.Data.Entities;
+using DutchTreat.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DutchTreat.Controllers
+{
+  [Route("/api/orders/{orderId}/items")]
+  public class OrderItemsController : Controller
+  {
+    private readonly IDutchRepository _dutchRepository;
+    private readonly ILogger<OrderItemsController> _logger;
+    private readonly IMapper _mapper;
+
+    public OrderItemsController(IDutchRepository dutchRepository,
+      ILogger<OrderItemsController> logger,
+      IMapper mapper)
+    {
+      _dutchRepository = dutchRepository;
+      _logger = logger;
+      _mapper = mapper;
+    }
+
+    [HttpGet]
+    public IActionResult Get(int orderId)
+    {
+      var order = _dutchRepository.GetOrderById(orderId);
+      if (order != null) return Ok(_mapper.Map<IEnumerable<OrderItem>, IEnumerable<OrderItemViewModel>>(order.Items));
+      return NotFound();
+    }
+
+    [HttpGet("{id}")]
+    public IActionResult Get(int orderId, int id)
+    {
+      var order = _dutchRepository.GetOrderById(orderId);
+      if (order != null)
+      {
+        var item = order.Items.Where(i => i.Id == id).FirstOrDefault();
+        if (item != null)
+        {
+          return Ok(_mapper.Map<OrderItem, OrderItemViewModel>(item));
+        }
+      }
+      return NotFound();
+    }
+
+    //create methods for post, delete in order to add new items, delete, update
+    //http://shawnw.me/corewebapi
+
+  }
+}

--- a/DutchTreat/Data/DutchMappingProfile.cs
+++ b/DutchTreat/Data/DutchMappingProfile.cs
@@ -16,6 +16,8 @@ namespace DutchTreat.Data
         .ForMember(ov => ov.OrderId,
         map => map.MapFrom(o => o.Id))
         .ReverseMap();
+
+      CreateMap<OrderItem, OrderItemViewModel>().ReverseMap();
     }
   }
 }

--- a/DutchTreat/ViewModels/OrderItemViewModel.cs
+++ b/DutchTreat/ViewModels/OrderItemViewModel.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace DutchTreat.ViewModels
+{
+  public class OrderItemViewModel
+  {
+    public int Id { get; set; }
+
+    [Required]
+    public int Quantity { get; set; }
+    [Required]
+    public decimal UnitPrice { get; set; }
+
+    [Required]
+    public int ProductId { get; set; }
+
+    /// <summary>
+    /// automapper convention to fetch related product information
+    /// add Product as the prefix to the property. the mapper automatically 
+    /// maps it
+    /// </summary>
+    public string ProductCategory { get; set; }
+    public string ProductSize { get; set; }
+    public string ProductTitle { get; set; }
+    public string ProductArtist { get; set; }
+    public string ProductArtId { get; set; }
+  }
+}

--- a/DutchTreat/ViewModels/OrderViewModel.cs
+++ b/DutchTreat/ViewModels/OrderViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace DutchTreat.ViewModels
@@ -10,5 +11,7 @@ namespace DutchTreat.ViewModels
     [Required]
     [MinLength(4)]
     public string OrderNumber { get; set; }
+
+    public ICollection<OrderItemViewModel> Items { get; set; }
   }
 }


### PR DESCRIPTION
Mapping related entities using automapper.
How to Route related entity apis. Routing /api/orders/id/items/id
Mapped OrderItem to View Model.
How to use automapper convention of fetching related entity information using
EntityName as the prefix to the entity's property in the related entity.

Example, while fetching orderItem if we need Product information, we could fetch the properties of product that we are interested in by introducing product's properties in OrderItemViewModel with Product as a prefix to it.