### PR TITLE
feat(queryStringParam): Optional params

### DIFF
--- a/DutchTreat/Controllers/OrdersController.cs
+++ b/DutchTreat/Controllers/OrdersController.cs
@@ -23,12 +23,17 @@ namespace DutchTreat.Controllers
       _mapper = mapper;
     }
 
+    /// <summary>
+    /// Optional bool for query string. 
+    /// </summary>
+    /// <param name="includeItem"></param>
+    /// <returns></returns>
     [HttpGet]
-    public IActionResult Get()
+    public IActionResult Get(bool includeItem = true)
     {
       try
       {
-        return Ok(_mapper.Map<IEnumerable<Order>, IEnumerable<OrderViewModel>>(_dutchRepository.GetAllOrders()));
+        return Ok(_mapper.Map<IEnumerable<Order>, IEnumerable<OrderViewModel>>(_dutchRepository.GetAllOrders(includeItem)));
       }
       catch (System.Exception ex)
       {

--- a/DutchTreat/Data/DutchRepository.cs
+++ b/DutchTreat/Data/DutchRepository.cs
@@ -31,12 +31,20 @@ namespace DutchTreat.Data
     /// and order item products
     /// </summary>
     /// <returns></returns>
-    public IEnumerable<Order> GetAllOrders()
+    public IEnumerable<Order> GetAllOrders(bool includeItems)
     {
-      return _ctx.Orders
+      if (includeItems)
+      {
+        return _ctx.Orders
         .Include(o => o.Items)
         .ThenInclude(oi => oi.Product)
         .ToList();
+      }
+      else
+      {
+        return _ctx.Orders
+        .ToList();
+      }
     }
 
     public IEnumerable<Product> GetAllProducts()

--- a/DutchTreat/Data/IDutchRepository.cs
+++ b/DutchTreat/Data/IDutchRepository.cs
@@ -8,7 +8,7 @@ namespace DutchTreat.Data
     IEnumerable<Product> GetAllProducts();
     IEnumerable<Product> GetProductsByCategory(string category);
 
-    IEnumerable<Order> GetAllOrders();
+    IEnumerable<Order> GetAllOrders(bool includeItem);
     Order GetOrderById(int id);
 
     bool SaveAll();


### PR DESCRIPTION
Usecases where you would want to manipulate return data or limit it.
Using query string params are useful in such cases.
Added an optional param which is true by default can be negated to return only orders without including order items.